### PR TITLE
Update to Kotlin 1.9.20

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     implementation("com.palantir.gradle.gitversion:gradle-git-version:3.0.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    kotlin("jvm") version "1.8.21" apply false
+    kotlin("jvm") version "1.9.20" apply false
 }

--- a/kotbridge-plugin-kotlin/build.gradle.kts
+++ b/kotbridge-plugin-kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("publish")
 
-    kotlin("kapt") version "1.8.21"
+    kotlin("kapt") version "1.9.20"
 }
 
 dependencies {

--- a/kotbridge-plugin-kotlin/src/main/kotlin/com/github/tarcv/kotbridge/plugin/CaptureTransformer.kt
+++ b/kotbridge-plugin-kotlin/src/main/kotlin/com/github/tarcv/kotbridge/plugin/CaptureTransformer.kt
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.sourceElement
-import org.jetbrains.kotlin.backend.jvm.ir.getValueArgument
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -28,7 +27,6 @@ import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.checker.SimpleClassicTypeSystemContext.isNullableType
 import java.io.File
 import java.math.BigInteger
@@ -248,11 +246,16 @@ class CaptureTransformer(
                         it.symbol.owner.constructedClass.kotlinFqName.asString() == converterInfoFqn
                     }
                     ?: return@foldRight acc
+                val argumentIndeces = annotation.symbol.owner.valueParameters
+                    .mapIndexed { index, parameter -> parameter.name.asString() to index }
+                    .toMap()
                 RequestedConverters(
-                    annotation.getValueArgument(Name.identifier("fromJsConverter"))
+                    argumentIndeces["fromJsConverter"]
+                        ?.let { index -> annotation.getValueArgument(index) }
                         ?.asAnnotationArgumentValueAsString(converterInfoFqn)
                         ?: acc.fromJs,
-                    annotation.getValueArgument(Name.identifier("toJsConverter"))
+                    argumentIndeces["toJsConverter"]
+                        ?.let { index -> annotation.getValueArgument(index) }
                         ?.asAnnotationArgumentValueAsString(converterInfoFqn)
                         ?: acc.toJs
                 )

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -84,7 +84,7 @@ sourceSets.forEach { set ->
                     import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
                     
                     plugins {
-                        kotlin("multiplatform") version "1.8.21" apply false
+                        kotlin("multiplatform") version "1.9.20" apply false
                     }
                     repositories {
                         mavenCentral()


### PR DESCRIPTION
With this release Kotlin Multiplatform enters Beta. And its Gradle plugin should have better support for Gradle caches. All of the above is quite useful for development of this project.